### PR TITLE
Updated __construct

### DIFF
--- a/src/Models/Address.php
+++ b/src/Models/Address.php
@@ -41,9 +41,9 @@ class Address extends Model
     /**
      * @inheritdoc
      */
-    public function __construct()
+    public function __construct(array $attributes = [])
     {
-        parent::__construct();
+        parent::__construct($attributes);
 
         $this->table = config('lecturize.addresses.table', 'addresses');
     }


### PR DESCRIPTION
Added $attributes array

It seems there is an compatibility issue with Laravel 5.4 (maybe other versions as well).

The addresses where created with empty values.

I suspected that it is the same problem as [this](https://laracasts.com/discuss/channels/general-discussion/eloquent-create-method-always-inserts-blank-entries).

I tested the solution and it worked for me. The change as seen in the link is simply changing 
this:

```php
    public function __construct()
    {
        parent::__construct();
        $this->table = config('lecturize.addresses.table', 'addresses');
    }
```

to this:
```php
    public function __construct(array $attributes = array())
    {
        parent::__construct($attributes);
        $this->table = config('lecturize.addresses.table', 'addresses');
    }
```
A colleague mentioned ( I do not have any link so far to support this claim) that things like this should be handled in boot and not constuct anymore.

So maybe there even is a more up to date method to pass the attributes.