### PR TITLE
Adding custom columns feature

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -16,6 +16,11 @@ return [
         'flags' => ['public', 'primary', 'billing', 'shipping'],
 
         /*
+         * Extra columns to be added to the fillable array
+         */
+        'columns' => [],
+
+        /*
          * Enable geocoding to add coordinates (lon/lat) to addresses
          */
         'geocode' => true,

--- a/src/Models/Address.php
+++ b/src/Models/Address.php
@@ -17,23 +17,7 @@ class Address extends Model
     /**
      * @inheritdoc
      */
-    protected $fillable = [
-        'street',
-        'street_extra',
-        'city',
-        'state',
-        'post_code',
-        'country_id',
-        'note',
-        'lat',
-        'lng',
-        'addressable_id',
-        'addressable_type',
-        'is_public',
-        'is_primary',
-        'is_billing',
-        'is_shipping',
-    ];
+    protected $fillable = [];
 
     /**
      * @inheritdoc
@@ -45,9 +29,40 @@ class Address extends Model
      */
     public function __construct(array $attributes = [])
     {
+        $this->setFillable();
+
         parent::__construct($attributes);
 
         $this->table = config('lecturize.addresses.table', 'addresses');
+    }
+
+    private function setFillable()
+    {
+        $fixed =  [
+            'street',
+            'street_extra',
+            'city',
+            'state',
+            'post_code',
+            'country_id',
+            'note',
+            'lat',
+            'lng',
+            'addressable_id',
+            'addressable_type'
+        ];
+
+        // load custom columns from config
+        $custom_columns = config('lecturize.addresses.columns', array());
+
+        // load flags from config and prepend "is_"
+        $custom_flags = config('lecturize.addresses.flags', array());
+        $custom_flags = array_map(function($val) { return "is_" . $val;} , $flags);
+
+        $fields = array_merge($fixed, $custom_columns, $custom_flags);
+
+        $this->fillable($fields);
+
     }
 
     /**


### PR DESCRIPTION
Implementing a new private setFillable() method which generates the `fillable` attributes for the Addresses model.

It's a combination of: 
1. hardcoded table names (from the migrations)
1. any columns in the `columns` array in the config
1. any columns in the `flags` array in the config, with 'is_' prepended to them

see #15