### PR TITLE
Allow using custom Models for Address and Contact

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ $post->addContact([
 Above all, `addresses` and `contacts` can be connected with an optional One To Many relationship. Like so you could assign multiple contacts to an address and retrieve them like so:
 
 ```php
-$address = config('lecturize.addresses.model')::find(1);
+$address = config('lecturize.addresses.model', \Lecturize\Addresses\Models\Address::class)::find(1);
 $contacts = $address->contacts;
 
 foreach ($contacts as $contact) {
@@ -163,13 +163,13 @@ foreach ($contacts as $contact) {
 ```
 
 ```php
-$contact = config('lecturize.addresses.model')::find(1)
+$contact = config('lecturize.contacts.model', \Lecturize\Addresses\Models\Contact::class)::find(1)
                   ->contacts()
                   ->first();
 ```
 
 ```php
-$contact = config('lecturize.contacts.model')::find(1);
+$contact = config('lecturize.contacts.model', \Lecturize\Addresses\Models\Contact::class)::find(1);
 
 return $contact->address->getHtml();
 ```

--- a/README.md
+++ b/README.md
@@ -154,9 +154,7 @@ $post->addContact([
 Above all, `addresses` and `contacts` can be connected with an optional One To Many relationship. Like so you could assign multiple contacts to an address and retrieve them like so:
 
 ```php
-use Lecturize\Addresses\Models\Address;
-
-$address = Address::find(1);
+$address = config('lecturize.addresses.model')::find(1);
 $contacts = $address->contacts;
 
 foreach ($contacts as $contact) {
@@ -165,17 +163,13 @@ foreach ($contacts as $contact) {
 ```
 
 ```php
-use Lecturize\Addresses\Models\Address;
-
-$contact = Address::find(1)
+$contact = config('lecturize.addresses.model')::find(1)
                   ->contacts()
                   ->first();
 ```
 
 ```php
-use Lecturize\Addresses\Models\Contact;
-
-$contact = Contact::find(1);
+$contact = config('lecturize.contacts.model')::find(1);
 
 return $contact->address->getHtml();
 ```

--- a/config/config.php
+++ b/config/config.php
@@ -11,6 +11,11 @@ return [
         'table' => 'addresses',
 
         /*
+         * The model used for addresses.
+         */
+        'model' => \Lecturize\Addresses\Models\Address::class,
+
+        /*
          * Flag columns to be added to table.
          */
         'flags' => ['public', 'primary', 'billing', 'shipping'],
@@ -42,6 +47,11 @@ return [
          * Main table.
          */
         'table' => 'contacts',
+
+        /*
+         * The model used for contacts.
+         */
+        'model' => \Lecturize\Addresses\Models\Contact::class,
 
         /*
          * Flag columns to be added to table.

--- a/src/Traits/HasAddresses.php
+++ b/src/Traits/HasAddresses.php
@@ -22,7 +22,7 @@ trait HasAddresses
     public function addresses(): MorphMany
     {
         /** @var Model $this */
-        return $this->morphMany(Address::class, 'addressable');
+        return $this->morphMany(config('lecturize.addresses.model'), 'addressable');
     }
 
     public function hasAddresses(): bool
@@ -112,7 +112,8 @@ trait HasAddresses
 
     function validateAddress(array $attributes): Validator
     {
-        $rules = (new Address)->getValidationRules();
+        $model = config('lecturize.addresses.model');
+        $rules = (new $model)->getValidationRules();
 
         return validator($attributes, $rules);
     }

--- a/src/Traits/HasAddresses.php
+++ b/src/Traits/HasAddresses.php
@@ -22,7 +22,7 @@ trait HasAddresses
     public function addresses(): MorphMany
     {
         /** @var Model $this */
-        return $this->morphMany(config('lecturize.addresses.model'), 'addressable');
+        return $this->morphMany(config('lecturize.addresses.model', Address::class), 'addressable');
     }
 
     public function hasAddresses(): bool
@@ -112,7 +112,7 @@ trait HasAddresses
 
     function validateAddress(array $attributes): Validator
     {
-        $model = config('lecturize.addresses.model');
+        $model = config('lecturize.addresses.model', Address::class);
         $rules = (new $model)->getValidationRules();
 
         return validator($attributes, $rules);

--- a/src/Traits/HasContacts.php
+++ b/src/Traits/HasContacts.php
@@ -21,7 +21,7 @@ trait HasContacts
     public function contacts(): MorphMany
     {
         /** @var Model $this */
-        return $this->morphMany(config('lecturize.contacts.model'), 'contactable');
+        return $this->morphMany(config('lecturize.contacts.model', Contact::class), 'contactable');
     }
 
     public function hasContacts(): bool
@@ -77,7 +77,7 @@ trait HasContacts
 
     function validateContact(array $attributes): Validator
     {
-        $rules = config('lecturize.contacts.model')::getValidationRules();
+        $rules = config('lecturize.contacts.model', Contact::class)::getValidationRules();
 
         return validator($attributes, $rules);
     }

--- a/src/Traits/HasContacts.php
+++ b/src/Traits/HasContacts.php
@@ -21,7 +21,7 @@ trait HasContacts
     public function contacts(): MorphMany
     {
         /** @var Model $this */
-        return $this->morphMany(Contact::class, 'contactable');
+        return $this->morphMany(config('lecturize.contacts.model'), 'contactable');
     }
 
     public function hasContacts(): bool
@@ -77,7 +77,7 @@ trait HasContacts
 
     function validateContact(array $attributes): Validator
     {
-        $rules = Contact::getValidationRules();
+        $rules = config('lecturize.contacts.model')::getValidationRules();
 
         return validator($attributes, $rules);
     }

--- a/src/Traits/OwnsAddresses.php
+++ b/src/Traits/OwnsAddresses.php
@@ -20,13 +20,13 @@ trait OwnsAddresses
     public function addresses(): HasMany
     {
         /** @var Model $this */
-        return $this->hasMany(config('lecturize.addresses.model'));
+        return $this->hasMany(config('lecturize.addresses.model', Address::class));
     }
 
     public function contacts(): HasMany
     {
         /** @var Model $this */
-        return $this->hasMany(config('lecturize.contacts.model'));
+        return $this->hasMany(config('lecturize.contacts.model', Contact::class));
     }
 
     /** @return Address[]|Collection */

--- a/src/Traits/OwnsAddresses.php
+++ b/src/Traits/OwnsAddresses.php
@@ -20,13 +20,13 @@ trait OwnsAddresses
     public function addresses(): HasMany
     {
         /** @var Model $this */
-        return $this->hasMany(Address::class);
+        return $this->hasMany(config('lecturize.addresses.model'));
     }
 
     public function contacts(): HasMany
     {
         /** @var Model $this */
-        return $this->hasMany(Contact::class);
+        return $this->hasMany(config('lecturize.contacts.model'));
     }
 
     /** @return Address[]|Collection */


### PR DESCRIPTION
This PR introduces a feature that allows overriding the `Address` and `Contact` model which let's users define custom functionality and implementations on these models. This ensures more flexibility in case of modifying migrations / adding columns / changing query behaviour, etc.