### PR TITLE
Add fallback logic to address flags (closes #32)

### DIFF
--- a/src/Models/Address.php
+++ b/src/Models/Address.php
@@ -246,16 +246,24 @@ class Address extends Model
         return '';
     }
 
+    public function scopeFlag(Builder $query, string $flag): Builder
+    {
+        return $query->where('is_'.$flag, true);
+    }
+
+    /* Deprecated: use scopeFlag('primary') instead */
     public function scopePrimary(Builder $query): Builder
     {
         return $query->where('is_primary', true);
     }
 
+    /* Deprecated: use scopeFlag('billing') instead */
     public function scopeBilling(Builder $query): Builder
     {
         return $query->where('is_billing', true);
     }
 
+    /* Deprecated: use scopeFlag('shipping') instead */
     public function scopeShipping(Builder $query): Builder
     {
         return $query->where('is_shipping', true);

--- a/src/Traits/HasAddresses.php
+++ b/src/Traits/HasAddresses.php
@@ -102,7 +102,7 @@ trait HasAddresses
              * use the array order of config lecturize.addresses.flags to build up
              * a fallback solution for when no address with the given flag exists
              */
-            $fallback_order = config('lecturize.addresses.flags');
+            $fallback_order = config('lecturize.addresses.flags', []);
 
             /**
              * fallback order is an array of flags like: ['public', 'primary', 'billing', 'shipping']

--- a/src/Traits/HasAddresses.php
+++ b/src/Traits/HasAddresses.php
@@ -82,7 +82,7 @@ trait HasAddresses
         return $this->addresses()->delete();
     }
 
-    public function getAddressByFlag(?string $flag = null, string $direction = 'desc', int $fallback_iterations = 0): ?Address
+    public function getAddressByFlag(?string $flag = null, string $direction = 'desc'): ?Address
     {
         if (! $this->hasAddresses()) {
             return null; // short circuit if no addresses exist

--- a/src/Traits/HasAddresses.php
+++ b/src/Traits/HasAddresses.php
@@ -82,7 +82,7 @@ trait HasAddresses
         return $this->addresses()->delete();
     }
 
-    public function getAddressByFlag(?string $flag = null, string $direction = 'desc'): ?Address
+    protected function getAddressByFlag(?string $flag = null, string $direction = 'desc'): ?Address
     {
         if (! $this->hasAddresses()) {
             return null; // short circuit if no addresses exist

--- a/src/Traits/HasAddresses.php
+++ b/src/Traits/HasAddresses.php
@@ -7,6 +7,7 @@ use Illuminate\Contracts\Validation\Validator;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\MorphMany;
 use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Support\Str;
 
 use Lecturize\Addresses\Models\Address;
 use Lecturize\Addresses\Exceptions\FailedValidationException;
@@ -19,6 +20,30 @@ use Lecturize\Addresses\Models\Country;
  */
 trait HasAddresses
 {
+    /**
+     * This method allows for dynamic method calls to retrieve addresses by their associated flags,
+     * which can be useful for managing addresses with different purposes or locations
+     *
+     * @param string $method
+     * @param array $parameters
+     *
+     */
+    public function __call($method, $parameters)
+    {
+        $available_flags = config('lecturize.addresses.flags');
+        $available_flags = array_map(function ($flag) {
+            return Str::ucfirst($flag);
+        }, $available_flags);
+
+        if (preg_match('/^get(' . implode('|', $available_flags) . ')Address$/', $method, $matches)) {
+            $flag = strtolower($matches[1]);
+
+            return $this->getAddressByFlag($flag, $parameters[0] ?? 'desc');
+        }
+
+        return parent::__call($method, $parameters);
+    }
+
     public function addresses(): MorphMany
     {
         /** @var Model $this */
@@ -57,28 +82,55 @@ trait HasAddresses
         return $this->addresses()->delete();
     }
 
-    public function getPrimaryAddress(string $direction = 'desc'): ?Address
+    public function getAddressByFlag(?string $flag = null, string $direction = 'desc', int $fallback_iterations = 0): ?Address
     {
-        return $this->addresses()
-                    ->primary()
-                    ->orderBy('is_primary', $direction)
-                    ->first();
-    }
+        if (! $this->hasAddresses()) {
+            return null; // short circuit if no addresses exist
+        }
 
-    public function getBillingAddress(string $direction = 'desc'): ?Address
-    {
-        return $this->addresses()
-                    ->billing()
-                    ->orderBy('is_billing', $direction)
-                    ->first();
-    }
+        if ($flag !== null) {
+            $search_flag = 'is_' . $flag;
+            $address = $this->addresses()->where($search_flag, true)
+                ->orderBy($search_flag, $direction)
+                ->first();
 
-    public function getShippingAddress(string $direction = 'desc'): ?Address
-    {
-        return $this->addresses()
-                    ->shipping()
-                    ->orderBy('is_shipping', $direction)
-                    ->first();
+            if ($address !== null) {
+                return $address;
+            }
+
+            /**
+             * use the array order of config lecturize.addresses.flags to build up
+             * a fallback solution for when no address with the given flag exists
+             */
+            $fallback_order = config('lecturize.addresses.flags');
+
+            /**
+             * fallback order is an array of flags like: ['public', 'primary', 'billing', 'shipping']
+             * when calling getBillingAddress() and no address with the billing flag exists, the next earliest flag is used
+             * in this case, the flag 'primary' would be used
+             */
+            $current_flag_index = array_search($flag, $fallback_order);
+            $try_flag = $fallback_order[$current_flag_index - 1] ?? null;
+
+            if ($try_flag !== null) {
+                $address = $this->getAddressByFlag($try_flag, $direction);
+
+                if ($address !== null) {
+                    return $address;
+                }
+            }
+        }
+
+        /**
+         * should the default fallback logic fail, try to get the first or last address
+         */
+        if (! $address && $direction === 'desc') {
+            return $this->addresses()->first();
+        } elseif (! $address && $direction === 'asc') {
+            return $this->addresses()->last();
+        }
+
+        return null;
     }
 
     /** @throws FailedValidationException */


### PR DESCRIPTION
implements flag fallbacks for Addresses as described in #32 

### How does it work?
using the magic `__call` method we are searching the flags defined in config and eventually use them to retrieve the addresses.
We can still call methods like `getShippingAddress` and `getPrimaryAddress`, but instead of using a dedicated method for this we now can utilize the `getAddressByFlag` method which walks recursively through the `flags` array defined in the config.

So if the `flags` array looks like this:
```php
'flags' => ['public', 'primary', 'billing', 'shipping'],
```

and we are calling `getBillingAddress` the new implementation would walk up the array until it reaches the `public` flag if it cannot find any addresses earlier. It would not check for the `shipping` flag in this step.

After trying all flags and if there is still no address found based on the direction parameter the new implementation would either return the first or the last attached address as a last fallback step.

This ensures to return an address object in almost every situation.