### PR TITLE
allow querying contacts by flag

### DIFF
--- a/src/Traits/HasContacts.php
+++ b/src/Traits/HasContacts.php
@@ -7,6 +7,7 @@ use Illuminate\Contracts\Validation\Validator;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\MorphMany;
 use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Support\Str;
 
 use Lecturize\Addresses\Models\Contact;
 use Lecturize\Addresses\Exceptions\FailedValidationException;
@@ -18,6 +19,22 @@ use Lecturize\Addresses\Exceptions\FailedValidationException;
  */
 trait HasContacts
 {
+    public function __call($method, $parameters)
+    {
+        $available_flags = config('lecturize.contacts.flags');
+        $available_flags = array_map(function ($flag) {
+            return Str::ucfirst($flag);
+        }, $available_flags);
+
+        if (preg_match('/^get(' . implode('|', $available_flags) . ')Contact$/', $method, $matches)) {
+            $flag = strtolower($matches[1]);
+
+            return $this->getContactByFlag($flag);
+        }
+
+        return parent::__call($method, $parameters);
+    }
+
     public function contacts(): MorphMany
     {
         /** @var Model $this */
@@ -57,6 +74,58 @@ trait HasContacts
     public function flushContacts(): bool
     {
         return $this->contacts()->delete();
+    }
+
+    protected function getContactByFlag(?string $flag = null, string $direction = 'desc'): ?Contact
+    {
+        if (! $this->hasContacts()) {
+            return null;
+        }
+
+        if ($flag !== null) {
+            $search_flag = 'is_' . $flag;
+            $contact = $this->contacts()
+                ->where($search_flag, true)
+                ->orderBy('created_at', $direction)
+                ->first();
+
+            if ($contact !== null) {
+                return $contact;
+            }
+
+            /**
+             * use the array order of config lecturize.contacts.flags to build up
+             * a fallback solution for when no contact with the given flag exists
+             */
+            $fallback_order = config('lecturize.contacts.flags', []);
+
+            /**
+             * fallback order is an array of flags like: ['public', 'primary', 'billing', 'shipping']
+             * when calling getBillingAddress() and no address with the billing flag exists, the next earliest flag is used
+             * in this case, the flag 'primary' would be used
+             */
+            $current_flag_index = array_search($flag, $fallback_order);
+            $try_flag = $fallback_order[$current_flag_index - 1] ?? null;
+
+            if ($try_flag !== null) {
+                $contact = $this->getContactByFlag($try_flag, $direction);
+
+                if ($contact !== null) {
+                    return $contact;
+                }
+            }
+        }
+
+        /**
+         * should the default fallback logic fail, try to get the first or last contact
+         */
+        if (! $contact && $direction === 'desc') {
+            return $this->contacts()->first();
+        } elseif (! $contact && $direction === 'asc') {
+            return $this->contacts()->last();
+        }
+
+        return null;
     }
 
     /** @throws FailedValidationException */


### PR DESCRIPTION
Currently there is no simple way to query Contacts by a given flag. This PR adds the ability to query Contacts just like Addresses using `Model::getSomeflagContact()` where Someflag is a flag defined in the `lecturize.contacts.flags` config.

This builds up from #35 where I added a more adaptable way of querying flagged Addresses.