### PR TITLE
Fixes incorrect reference to config file

### DIFF
--- a/src/Models/Address.php
+++ b/src/Models/Address.php
@@ -146,7 +146,7 @@ class Address extends Model
     private function updateFillables(): void
     {
         $fillable = $this->fillable;
-        $columns  = preg_filter('/^/', 'is_', config('lecturize.addresses.columns', ['public', 'primary', 'billing', 'shipping']));
+        $columns  = preg_filter('/^/', 'is_', config('lecturize.addresses.flags', ['public', 'primary', 'billing', 'shipping']));
 
         $this->fillable(array_merge($fillable, $columns));
     }

--- a/src/Models/Contact.php
+++ b/src/Models/Contact.php
@@ -117,7 +117,7 @@ class Contact extends Model
     private function updateFillables(): void
     {
         $fillable = $this->fillable;
-        $columns  = preg_filter('/^/', 'is_', config('lecturize.addresses.columns', ['public', 'primary', 'billing', 'shipping']));
+        $columns  = preg_filter('/^/', 'is_', config('lecturize.contacts.flags', ['public', 'primary']));
 
         $this->fillable(array_merge($fillable, $columns));
     }


### PR DESCRIPTION
When changing the 'columns' key in the config file to 'flags', a few config references were missed in the Address and Contact model. The Contact model was also referencing the 'addresses' config instead of the 'contacts' config. Minor update, but crucial if you are implementing custom flags. Without the correct reference, the model's fillable property was not being updated thus now allowing you to set the flags when creating an address.