### PR TITLE
Correct the column rename in add_title_fields_to_contacts_table.php.stub

### DIFF
--- a/database/migrations/add_title_fields_to_contacts_table.php.stub
+++ b/database/migrations/add_title_fields_to_contacts_table.php.stub
@@ -16,7 +16,7 @@ class AddTitleFieldsToContactsTable extends Migration
     public function up(): void
     {
         Schema::table($this->table, function (Blueprint $table) {
-            $table->rename('title', 'title_before');
+            $table->renameColumn('title', 'title_before');
             $table->string('title_after')->nullable()->after('title_before');
         });
     }
@@ -24,7 +24,7 @@ class AddTitleFieldsToContactsTable extends Migration
     public function down(): void
     {
         Schema::table($this->table, function (Blueprint $table) {
-            $table->rename('title_before', 'title');
+            $table->renameColumn('title_before', 'title');
             $table->dropColumn('title_after');
         });
     }


### PR DESCRIPTION
I faced an issue with `$table->rename('title_before', 'title');` - it renames 'contacts` table and migration itself obviously failed with the following error:

```
SQLSTATE[42S02]: Base table or view not found: 1146 Table 'db.contacts' doesn't exist (Connection: mariadb, SQL: alter table `contacts` rename column `title` to `title_before`)
```